### PR TITLE
Deploying SAFE contracts on Ganache

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,5 +2,5 @@ MNEMONIC=""
 # Used for infura based network
 INFURA_KEY=""
 # Used for custom network
-NODE_URL=""
+NODE_URL="http://localhost:8545"
 ETHERSCAN_API_KEY=""

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -118,6 +118,11 @@ if (NODE_URL) {
   userConfig.networks!!.custom = {
     ...sharedNetworkConfig,
     url: NODE_URL,
+    /* 
+     Warning: don't do this in production; below is a test key
+     Provide the private key for the account you wish to deploy with
+     */
+    accounts: ['055f0d3a83c516835680d6f0a7ed1c4905a5c1442f8b07a510aa442770d401a3']
   }
 }
 export default userConfig

--- a/src/tasks/deploy_contracts.ts
+++ b/src/tasks/deploy_contracts.ts
@@ -6,7 +6,7 @@ task("deploy-contracts", "Deploys and verifies Safe contracts")
     .setAction(async (_, hre) => {
         await hre.run("deploy")
         await hre.run("local-verify")
-        await hre.run("etherscan-verify", { forceLicense: true, license: 'LGPL-3.0'})
+        // await hre.run("etherscan-verify", { forceLicense: true, license: 'LGPL-3.0'})
     });
 
 export { }


### PR DESCRIPTION
Ganache isn't directly supported, but you can deploy your SAFE contracts to a _**custom network**_ instead.

To do this, you'll need to:

1.  Point to the ganache RPC endpoint by setting`NODE_URL`; and 
2. Provide an ETH-funded account to pay for gas fees; and 
3. Disable **_etherscan verification_** if you don't have an Etherscan API key (otherwise the deploy fails)

When you're ready, you can deploy by issuing:
```
NODE_URL=http://localhost:8545 yarn deploy-all custom
```
